### PR TITLE
Add everness mineral water as dynamic liquid

### DIFF
--- a/everness.lua
+++ b/everness.lua
@@ -1,13 +1,13 @@
 local water_probability = dynamic_liquid.config.water_probability
 
 if dynamic_liquid.config.water then
-	-- mineral water is already not renewable,
+    -- mineral water is already not renewable,
     -- so it is not necessary to override it
-	local override_def = {liquid_renewable = false}
-	minetest.override_item("everness:mineral_water_source", override_def)
-	minetest.override_item("everness:mineral_water_flowing", override_def)
+    -- local override_def = {liquid_renewable = false}
+    -- minetest.override_item("everness:mineral_water_source", override_def)
+    -- minetest.override_item("everness:mineral_water_flowing", override_def)
 
-	dynamic_liquid.liquid_abm(
+    dynamic_liquid.liquid_abm(
         "everness:mineral_water_source",
         "everness:mineral_water_flowing",
         water_probability

--- a/everness.lua
+++ b/everness.lua
@@ -1,0 +1,15 @@
+local water_probability = dynamic_liquid.config.water_probability
+
+if dynamic_liquid.config.water then
+	-- mineral water is already not renewable,
+    -- so it is not necessary to override it
+	local override_def = {liquid_renewable = false}
+	minetest.override_item("everness:mineral_water_source", override_def)
+	minetest.override_item("everness:mineral_water_flowing", override_def)
+
+	dynamic_liquid.liquid_abm(
+        "everness:mineral_water_source",
+        "everness:mineral_water_flowing",
+        water_probability
+    )
+end

--- a/init.lua
+++ b/init.lua
@@ -56,3 +56,7 @@ end
 if minetest.get_modpath("mcl_core") then
 	dofile(modpath.."/mineclone.lua")
 end
+
+if minetest.get_modpath("everness") then
+	dofile(modpath.."/everness.lua")
+end

--- a/mod.conf
+++ b/mod.conf
@@ -1,3 +1,3 @@
 name = dynamic_liquid
-optional_depends = default, doc, xpanes, carts, mcl_core, mclx_core, mcl_mapgen_core, mcl_mapgen
+optional_depends = default, doc, xpanes, carts, mcl_core, mclx_core, mcl_mapgen_core, mcl_mapgen, everness
 description = Flowing dynamic liquids and ocean-maintenance springs.


### PR DESCRIPTION
The [everness](https://content.minetest.net/packages/SaKeL/everness/) mod contains a mineral water liquid. Sadly, it does not follow dynamic liquid rules.

This pull request aims to categorize mineral water as water. Players who install both the `dynamic_liquid` and `everness` mod, will see mineral water behave just like ordinary water.

One potential argument for denial of this pull request, is the argument that _that_ mod should contain cross-compatibility with this mod, not the other way around.